### PR TITLE
Fixed issue where variantUrlsForTarget() returns invalid urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+Fixed issue where `variantUrlsForTarget()` returns invalid urls
 
 ## 2.*
 

--- a/src/Handler/FileHandler.php
+++ b/src/Handler/FileHandler.php
@@ -115,7 +115,7 @@ class FileHandler implements FileHandlerInterface
     public function variantUrlsForTarget(TargetInterface $target, array $variants = []): array
     {
         $urls = [
-            static::ORIGINAL => $this->storage->url($target->original()),
+            static::ORIGINAL => $this->sanitizeUrl($this->storage->url($target->original())),
         ];
 
         if (in_array(static::ORIGINAL, $variants)) {
@@ -123,10 +123,35 @@ class FileHandler implements FileHandlerInterface
         }
 
         foreach ($variants as $variant) {
-            $urls[ $variant ] = $this->storage->url($target->variant($variant));
+            $urls[ $variant ] = $this->sanitizeUrl($this->storage->url($target->variant($variant)));
         }
 
         return $urls;
+    }
+
+    /**
+     * Removes invalid characters from the filename in the url.
+     *
+     * @param string $url the url coming from the storage
+     * @return bool
+     */
+    protected function sanitizeUrl(string $url): string
+    {
+        if (filter_var($url, FILTER_VALIDATE_URL)) {
+            return $url;
+        }
+
+        $parts = explode('/', $url);
+
+        if (empty($parts)) {
+            return $url;
+        }
+
+        $filename = array_pop($parts);
+
+        $parts []= urlencode($filename);
+
+        return implode('/', $parts);
     }
 
     /**

--- a/tests/Unit/Handler/FileHandlerTest.php
+++ b/tests/Unit/Handler/FileHandlerTest.php
@@ -270,6 +270,46 @@ class FileHandlerTest extends TestCase
         static::assertTrue($handler->deleteVariant($target, 'tiny'));
     }
 
+    /**
+     * @test
+     */
+    function it_handles_filenames_with_invalid_charachters()
+    {
+        $storage     = $this->getMockStorage();
+        $processor   = $this->getMockVariantProcessor();
+        $target      = $this->getMockTarget();
+        $invalidPath = 'test/target/path/original/space another space testëïóöü€é.mp4';
+        $cleanPath   = 'test/target/path/original/space+another+space+test%C3%AB%C3%AF%C3%B3%C3%B6%C3%BC%E2%82%AC%C3%A9.mp4';
+
+        $target->shouldReceive(FileHandler::ORIGINAL)
+            ->once()
+            ->andReturn($invalidPath);
+
+        $storage->shouldReceive('url')
+            ->with($invalidPath)
+            ->andReturn('http://test.com/' . $invalidPath);
+
+        $handler = new FileHandler($storage, $processor);
+
+        $urls = $handler->variantUrlsForTarget($target, [FileHandler::ORIGINAL]);
+
+        static::assertEquals('http://test.com/' . $cleanPath, $urls[FileHandler::ORIGINAL]);
+
+        $target->shouldReceive(FileHandler::ORIGINAL)
+            ->once()
+            ->andReturn($cleanPath);
+
+        $storage->shouldReceive('url')
+            ->with($cleanPath)
+            ->andReturn('http://test.com/' . $cleanPath);
+
+        $handler = new FileHandler($storage, $processor);
+
+        $urls = $handler->variantUrlsForTarget($target, [FileHandler::ORIGINAL]);
+
+        static::assertEquals('http://test.com/' . $cleanPath, $urls[FileHandler::ORIGINAL]);
+    }
+
 
     /**
      * @return Mockery\Mock|Mockery\MockInterface|StorageInterface


### PR DESCRIPTION
The `variantUrlsForTarget()` method is not checking if the url coming from the storage is valid. This PR fixes that.

I checked manually if the sanitized url is acessible in our storage by renaming [this file](https://s3.console.aws.amazon.com/s3/buckets/pxl-acceptance?region=eu-west-1&prefix=basiclabel/system/App/Models/FrontPage/FrontPageBlockImageTranslation/images/000/007/068/original/) in AWS and accessing [this link](https://pxl-acceptance.s3-eu-west-1.amazonaws.com/basiclabel/system/App/Models/FrontPage/FrontPageBlockImageTranslation/images/000/007/068/original/space+another+space+test%C3%AB%C3%AF%C3%B3%C3%B6%C3%BC%E2%82%AC%C3%A9.mp4) to go to the file.
