### PR TITLE
Laravel 11 Upgrade: Updated symfony/http-foundation to include version 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "imagine/imagine": "^1.2",
         "myclabs/php-enum": "^1.4",
         "psr/container": "^1.0|^2.0",
-        "symfony/http-foundation": "^3.0|^4.0|^5.0|^6.0",
+        "symfony/http-foundation": "^3.0|^4.0|^5.0|^6.0|^7.0",
         "ext-curl": "*"
     },
     "require-dev": {


### PR DESCRIPTION
Laravel 11 requires symphony/http-foundation ^7.0. Consequently, laravel-paperclip is conflicts with that requirement because of the required dependency in file-handling. This PR fixes the issue.